### PR TITLE
Fix Interface bugs

### DIFF
--- a/project-fortis-interfaces/src/components/Admin/AdminLocations.js
+++ b/project-fortis-interfaces/src/components/Admin/AdminLocations.js
@@ -130,8 +130,13 @@ export default class AdminLocations extends React.Component {
     }
 
     render() {
-        const { defaultZoomLevel, targetBbox, originalBounds, mapSvcToken, saving } = this.state;
+        const { defaultZoomLevel, mapSvcToken, saving } = this.state;
+        let { targetBbox, originalBounds } = this.state;
         const bboxRectangleColor = "#0ff";
+
+        if (typeof targetBbox  === 'string') targetBbox = targetBbox.split(',');
+        if (typeof originalBounds  === 'string') originalBounds = originalBounds.split(',');
+
         const bounds = targetBbox.length && targetBbox.length === 4 ? [[targetBbox[0], targetBbox[1]], [targetBbox[2], targetBbox[3]]] : [];
         const originalBoundsTarget = originalBounds.length && originalBounds.length === 4 ? [[originalBounds[0], originalBounds[1]], [originalBounds[2], originalBounds[3]]] : [];
 

--- a/project-fortis-interfaces/src/components/Admin/AdminSettings.js
+++ b/project-fortis-interfaces/src/components/Admin/AdminSettings.js
@@ -120,7 +120,7 @@ export const AdminSettings = createReactClass({
 
     const languageArray = supportedLanguages.value.split(",");
     const languageJSON = `["${languageArray.join('","')}"]`;
-    const bboxJSON = `[${targetBbox.value}]`
+    const bboxJSON = `[${targetBbox.value}]`;
     const site = {
       name: name.value,
       targetBbox: JSON.parse(bboxJSON),

--- a/project-fortis-interfaces/src/components/Admin/AdminWatchlist.js
+++ b/project-fortis-interfaces/src/components/Admin/AdminWatchlist.js
@@ -74,7 +74,7 @@ class AdminWatchlist extends React.Component {
       topic.translatednamelang = this.getTranslationLanguage()
       topic.translations = [{
         key: this.getTranslationLanguage(),
-        value: topic.translatedname
+        value: this.getDefaultLanguage() === this.getTranslationLanguage() ? topic.name : topic.translatedname 
       }]
       return topic;
     });


### PR DESCRIPTION
* Adding watchlist term used to fail, since there was no default value for topic translations if no translations were given. Now the value defaults to the original language's translation.
* Editing the geofence on sitesettings used to fail, since the value was sometimes passed as a comma delimited string, not a length 4 array.