### PR TITLE
Map Reposition

### DIFF
--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -56,10 +56,9 @@ export default class Dashboard extends React.Component {
     const watchlistResizedHeight = 0;
     this.setState({ newsfeedResizedHeight, watchlistResizedHeight, isHeatmapFullScreen: !this.state.isHeatmapFullScreen });
   }
-  clickMapReset() {
-    const newsfeedResizedHeight = 0;
-    const watchlistResizedHeight = 0;
-    this.setState({ newsfeedResizedHeight, watchlistResizedHeight, isHeatmapFullScreen: !this.state.isHeatmapFullScreen });
+
+  clickMapReset = () => {
+    this.refreshDashboard(false, this.props.settings.targetBbox);
   }
 
   filterLiterals() {
@@ -175,13 +174,16 @@ export default class Dashboard extends React.Component {
     );
   }
 
-  refreshDashboard = (includeCsv) => {
+  refreshDashboard = (includeCsv, replaceBbox) => {
     const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid, selectedplace } = this.filterLiterals();
-    this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, selectedplace);
+    if (replaceBbox === null) {
+      replaceBbox = bbox;
+    }
+    this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, replaceBbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, selectedplace);
   }
 
   refreshDashboardWithCsv = () => {
-    this.refreshDashboard(true);
+    this.refreshDashboard(true, null);
   }
 
   timelineComponent() {

--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -252,8 +252,6 @@ export default class Dashboard extends React.Component {
           </div>
           <div className="dashboard-action">
             <MapBoundingReset
-              tooltipOn="Click to reset map boundaries"
-              tooltipOff="Click to reset map boundaries"
               tooltipPosition="top-center"
               onClick={this.clickMapReset}
             />

--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -17,6 +17,7 @@ import '../../styles/Insights/Dashboard.css';
 import { changeCategory } from '../../routes/routes';
 import HeatmapToggle from './HeatmapToggle';
 import CategoryPicker from './CategoryPicker';
+import MapBoundingReset from './MapBoundingReset';
 import ShareButton from './ShareButton';
 import LanguagePicker from './LanguagePicker';
 

--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -178,7 +178,7 @@ export default class Dashboard extends React.Component {
     const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid, selectedplace } = this.filterLiterals();
 
     replaceBbox = replaceBbox || bbox;
-    
+
     this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, replaceBbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, selectedplace);
   }
 

--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -16,8 +16,8 @@ import 'react-grid-layout/css/styles.css';
 import '../../styles/Insights/Dashboard.css';
 import { changeCategory } from '../../routes/routes';
 import HeatmapToggle from './HeatmapToggle';
-import CategoryPicker from './CategoryPicker';
 import MapBoundingReset from './MapBoundingReset';
+import CategoryPicker from './CategoryPicker';
 import ShareButton from './ShareButton';
 import LanguagePicker from './LanguagePicker';
 

--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -176,9 +176,9 @@ export default class Dashboard extends React.Component {
 
   refreshDashboard = (includeCsv, replaceBbox) => {
     const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid, selectedplace } = this.filterLiterals();
-    if (replaceBbox === null) {
-      replaceBbox = bbox;
-    }
+
+    replaceBbox = replaceBbox || bbox;
+    
     this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, replaceBbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, selectedplace);
   }
 

--- a/project-fortis-interfaces/src/components/Insights/Dashboard.js
+++ b/project-fortis-interfaces/src/components/Insights/Dashboard.js
@@ -55,6 +55,11 @@ export default class Dashboard extends React.Component {
     const watchlistResizedHeight = 0;
     this.setState({ newsfeedResizedHeight, watchlistResizedHeight, isHeatmapFullScreen: !this.state.isHeatmapFullScreen });
   }
+  clickMapReset() {
+    const newsfeedResizedHeight = 0;
+    const watchlistResizedHeight = 0;
+    this.setState({ newsfeedResizedHeight, watchlistResizedHeight, isHeatmapFullScreen: !this.state.isHeatmapFullScreen });
+  }
 
   filterLiterals() {
     const { dataSource, zoomLevel, enabledStreams, selectedplace, flux, bbox, timespanType, termFilters, maintopic, externalsourceid, datetimeSelection, fromDate, toDate, language } = this.props;
@@ -240,6 +245,14 @@ export default class Dashboard extends React.Component {
               ]}
               tooltipPosition="top-center"
               fetchCsvs={this.refreshDashboardWithCsv}
+            />
+          </div>
+          <div className="dashboard-action">
+            <MapBoundingReset
+              tooltipOn="Click to reset map boundaries"
+              tooltipOff="Click to reset map boundaries"
+              tooltipPosition="top-center"
+              onClick={this.clickMapReset}
             />
           </div>
           <div className="dashboard-action">

--- a/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
+++ b/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import IconButton from 'material-ui/IconButton/IconButton';
-import NavigationFullscreen from 'material-ui/svg-icons/navigation/fullscreen';
-import NavigationFullscreenExit from 'material-ui/svg-icons/navigation/fullscreen-exit';
+import Map from 'material-ui/svg-icons/maps/map';
 import { fullWhite } from 'material-ui/styles/colors';
 
 export default class MapBoundingReset extends React.Component {
@@ -27,7 +26,7 @@ export default class MapBoundingReset extends React.Component {
     return (
       <div>
         <IconButton tooltip={expanded ? tooltipOff : tooltipOn} onClick={this.onClick} tooltipPosition={tooltipPosition}>
-          {expanded ? <NavigationFullscreenExit color={fullWhite} /> : <NavigationFullscreen color={fullWhite} />}
+          {expanded ? <Map color={fullWhite} /> : <Map color={fullWhite} />}
         </IconButton>
       </div>
     );

--- a/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
+++ b/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import IconButton from 'material-ui/IconButton/IconButton';
+import NavigationFullscreen from 'material-ui/svg-icons/navigation/fullscreen';
+import NavigationFullscreenExit from 'material-ui/svg-icons/navigation/fullscreen-exit';
+import { fullWhite } from 'material-ui/styles/colors';
+
+export default class MapBoundingReset extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      expanded: false
+    };
+  }
+
+  onClick = () => {
+    this.props.onClick();
+    this.setState({
+      expanded: !this.state.expanded
+    });
+  }
+
+  render() {
+    const { tooltipOn, tooltipOff, tooltipPosition } = this.props;
+    const { expanded } = this.state;
+
+    return (
+      <div>
+        <IconButton tooltip={expanded ? tooltipOff : tooltipOn} onClick={this.onClick} tooltipPosition={tooltipPosition}>
+          {expanded ? <NavigationFullscreenExit color={fullWhite} /> : <NavigationFullscreen color={fullWhite} />}
+        </IconButton>
+      </div>
+    );
+  }
+}

--- a/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
+++ b/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
@@ -4,11 +4,9 @@ import Map from 'material-ui/svg-icons/maps/map';
 import { fullWhite } from 'material-ui/styles/colors';
 
 export default class MapBoundingReset extends React.Component {
-  
   render() {
     const { tooltipPosition } = this.props;
     const tooltip = `Click to reset map boundaries.`;
-
 
     return (
       <div>

--- a/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
+++ b/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
@@ -4,10 +4,7 @@ import Map from 'material-ui/svg-icons/maps/map';
 import { fullWhite } from 'material-ui/styles/colors';
 
 export default class MapBoundingReset extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
+  
   render() {
     const { tooltipPosition } = this.props;
     const tooltip = `Click to reset map boundaries.`;

--- a/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
+++ b/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
@@ -6,25 +6,17 @@ import { fullWhite } from 'material-ui/styles/colors';
 export default class MapBoundingReset extends React.Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      expanded: false
-    };
-  }
-
-  onClick = () => {
-    this.props.onClick();
   }
 
   render() {
     const { tooltipPosition } = this.props;
-    const tooltip = `Click to reset map boundaries. `;
+    const tooltip = `Click to reset map boundaries.`;
 
 
     return (
       <div>
-        <IconButton tooltip={tooltip} onClick={this.onClick} tooltipPosition={tooltipPosition}>
-          {<Map color={fullWhite} />}
+        <IconButton tooltip={tooltip} onClick={this.props.onClick} tooltipPosition={tooltipPosition}>
+          <Map color={fullWhite} />
         </IconButton>
       </div>
     );

--- a/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
+++ b/project-fortis-interfaces/src/components/Insights/MapBoundingReset.js
@@ -14,19 +14,17 @@ export default class MapBoundingReset extends React.Component {
 
   onClick = () => {
     this.props.onClick();
-    this.setState({
-      expanded: !this.state.expanded
-    });
   }
 
   render() {
-    const { tooltipOn, tooltipOff, tooltipPosition } = this.props;
-    const { expanded } = this.state;
+    const { tooltipPosition } = this.props;
+    const tooltip = `Click to reset map boundaries. `;
+
 
     return (
       <div>
-        <IconButton tooltip={expanded ? tooltipOff : tooltipOn} onClick={this.onClick} tooltipPosition={tooltipPosition}>
-          {expanded ? <Map color={fullWhite} /> : <Map color={fullWhite} />}
+        <IconButton tooltip={tooltip} onClick={this.onClick} tooltipPosition={tooltipPosition}>
+          {<Map color={fullWhite} />}
         </IconButton>
       </div>
     );

--- a/project-fortis-interfaces/src/components/Insights/TimeSeriesGraph.js
+++ b/project-fortis-interfaces/src/components/Insights/TimeSeriesGraph.js
@@ -89,12 +89,13 @@ export default class TimeSeriesGraph extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (hasChanged(this.props, nextProps)){
       this.refreshChart(nextProps);
+    }
   }
 
   resetTimeline = () => {
     this.props.refreshDashboardFunction(false, null);
     this.setState({timelineHasBeenCustomized: false});
-}
+  }
 
   handleDataFetch = () => {
     const { dataSource, timespanType, bbox, selectedplace, termFilters, timeSeriesGraphData, zoomLevel, externalsourceid, maintopic } = this.props;

--- a/project-fortis-interfaces/src/components/Insights/TimeSeriesGraph.js
+++ b/project-fortis-interfaces/src/components/Insights/TimeSeriesGraph.js
@@ -89,13 +89,12 @@ export default class TimeSeriesGraph extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (hasChanged(this.props, nextProps)){
       this.refreshChart(nextProps);
-    }
   }
 
   resetTimeline = () => {
-    this.props.refreshDashboardFunction();
+    this.props.refreshDashboardFunction(false, null);
     this.setState({timelineHasBeenCustomized: false});
-  }
+}
 
   handleDataFetch = () => {
     const { dataSource, timespanType, bbox, selectedplace, termFilters, timeSeriesGraphData, zoomLevel, externalsourceid, maintopic } = this.props;


### PR DESCRIPTION
This addresses https://github.com/CatalystCode/project-fortis-pipeline/issues/187 

However, I noticed that while the states are correctly getting updated when the map reset button is clicked, the call to refreshDashboard isn't actually re-positioning the map. 

Is there already a function to reposition the map that I'm missing somewhere, or do we need to write something new?