### PR TITLE
Improve blacklist user experience

### DIFF
--- a/project-fortis-interfaces/src/components/Admin/Admin.js
+++ b/project-fortis-interfaces/src/components/Admin/Admin.js
@@ -5,9 +5,12 @@ import { AdminSettings } from './AdminSettings';
 import AdminWatchlist from './AdminWatchlist';
 import { CustomEventsEditor } from './CustomEventsEditor';
 import TrustedSources from './TrustedSources';
-import { BlacklistEditor } from './BlacklistEditor';
+import BlacklistEditor from './BlacklistEditor';
 import StreamEditor from './StreamEditor';
 import UserRoles from './UserRoles';
+import FontIcon from 'material-ui/FontIcon';
+import ReactTooltip from 'react-tooltip'
+import {blue500, blue700} from 'material-ui/styles/colors';
 import '../../styles/Admin/Admin.css';
 
 const SETTINGS_TAB = 0;
@@ -41,7 +44,9 @@ class Admin extends React.Component {
   }
 
   closeModal = () => {
-    this.setState({ showModal: false });
+    this.setState({ 
+      showModal: false
+    });
   }
 
   openModal = () => {
@@ -117,7 +122,10 @@ class Admin extends React.Component {
                       </div>
                     </TabPanel>
                     <TabPanel>
-                      <h2>Blacklisted Terms</h2>
+                      <h2>Blacklisted Terms <FontIcon className="fa fa-question" data-tip data-for='blacklist' data-place='right' color={blue500} hoverColor={blue700}/></h2>
+                      <ReactTooltip id='blacklist'>
+                        <span>Provide a comma delimited list of blacklist terms, i.e. hunger, flood, hurricane. If an event matches all the blacklist terms, then it will be discarded.</span>
+                      </ReactTooltip>
                       <div className="adminTable">
                         {this.props.settings && this.props.settings.properties && this.state.index === BLACKLIST_TAB &&
                           <BlacklistEditor {...this.props}/>}

--- a/project-fortis-interfaces/src/components/Admin/DataGrid.js
+++ b/project-fortis-interfaces/src/components/Admin/DataGrid.js
@@ -118,7 +118,7 @@ export const DataGrid = createReactClass({
     }
 
     selectedRowKeys = [];
-    this.setState({rows, localAction, selectedRowKeys, modifiedRows, filters});
+    this.setState({rows, localAction: STATE_ACTIONS.MODIFIED, selectedRowKeys, modifiedRows, filters});
   },
   lookupRowIdByKey(rowKey) {
     let targetRowId = -1;
@@ -170,7 +170,7 @@ export const DataGrid = createReactClass({
     rows.unshift(newRow);
 
     const selectedRowKeys = [];
-    this.setState({rows, selectedRowKeys});
+    this.setState({rows, selectedRowKeys, localAction: STATE_ACTIONS.MODIFIED});
   },
   handleGridRowsUpdated(updatedRowData) {
       let rows = this.state.rows;
@@ -196,7 +196,7 @@ export const DataGrid = createReactClass({
                           }
 
                           modifiedRows.delete(rowKey);
-                          this.setState({ modifiedRows, localAction, rows});
+                          this.setState({ modifiedRows, localAction: STATE_ACTIONS.MODIFIED, rows});
                       });
                   }
               }
@@ -469,6 +469,7 @@ export const DataGrid = createReactClass({
               : undefined
             }
             <span style={styles.rowSelectionLabel}>{this.state.selectedRowKeys.length} {rowText} selected</span>
+
             <ReactDataGrid
                   ref="grid"
                   onGridSort={this.handleGridSort}

--- a/project-fortis-interfaces/src/routes/AdminPage.js
+++ b/project-fortis-interfaces/src/routes/AdminPage.js
@@ -33,6 +33,7 @@ export const AdminPage = createReactClass({
       watchlist,
       streams,
       translatableFields,
+      blacklist
     } = this.getStateFromFlux().adminStoreState;
 
 
@@ -50,7 +51,8 @@ export const AdminPage = createReactClass({
       trustedSources,
       streams,
       translatableFields,
-      enabledStreams
+      enabledStreams,
+      blacklist
     });
   },
 

--- a/project-fortis-pipeline/docs/user/admin.md
+++ b/project-fortis-pipeline/docs/user/admin.md
@@ -44,15 +44,6 @@ For example, in Excel you may have:
 | armed conflict      | gun           |
 | health              | medicine      |
 
-## Monitored Places / Geofence
-
-Specify coordinates and the zoom level of a location you would like to monitor.
-
-| Value               | Description   |
-| ------------------- | ------------- |
-| Target Bbox         | Uses `WOF`. Provide a comma delimited string `maxY,minX,minY,maxX` |
-| Zoom Level          | Specify as an `Integer`. |
-
 ## Event Import
 
 Still needs to be implemented.
@@ -89,12 +80,12 @@ A table of all supported `trusted sources` with their associated `pipeline keys`
 
 ## Blacklisted Terms
 
-Manage keywords to blacklist in the pipeline. For example, if you have `["Trump", "Obama", "election"]` in your blacklist, then events containing one or more of these keywords will be filtered in the pipeline and will not be displayed on the ui.
+Manage keywords to blacklist in the pipeline. For example, if you have `Trump, Obama, election` in your blacklist, then events containing one or more of these keywords will be filtered in the pipeline and will not be displayed on the ui.
 
 | Column Name         | Description   |
 | ------------------- | ------------- |
-| Id                  | Autopopulated `guid` of blacklisted term list. |
-| Blacklisted Terms   | Enter a grouping of keywords for a blacklist as an array of strings `["Trump", "Obama", "election"]`. |
+| Blacklisted Terms   | Enter a grouping of keywords for a blacklist as a comma delimited string: Trump, Obama, election. |
+| Is Location | A boolean specifying whether the blacklist should only be only applied to a particular location. |
 
 ## Streams
 

--- a/project-fortis-services/src/resolvers/Settings/mutations.js
+++ b/project-fortis-services/src/resolvers/Settings/mutations.js
@@ -396,18 +396,11 @@ function modifyBlacklist(args, res) { // eslint-disable-line no-unused-vars
     const mutations = [];
     const filterRecords = [];
     termFilters.forEach(termFilter => {
-      if (termFilter.id) {
-        mutations.push({
-          query: 'UPDATE fortis.blacklist SET conjunctivefilter = ?, islocation = ? WHERE id = ?',
-          params: [termFilter.filteredTerms, termFilter.isLocation, termFilter.id]
-        });
-      } else {
-        termFilter.id = uuid();
-        mutations.push({
-          query: 'INSERT INTO fortis.blacklist (id, conjunctivefilter, islocation) VALUES (?, ?, ?)',
-          params: [termFilter.id, termFilter.filteredTerms, termFilter.isLocation]
-        });
-      }
+      if (!termFilter.id) termFilter.id = uuid();
+      mutations.push({
+        query: 'UPDATE fortis.blacklist SET conjunctivefilter = ?, islocation = ? WHERE id = ?',
+        params: [termFilter.filteredTerms, termFilter.isLocation, termFilter.id]
+      });
       filterRecords.push(termFilter);
     });
 


### PR DESCRIPTION
* Allow `blacklist` terms to be entered in the table as `comma delimited strings` rather than an array of strings
* Remove `flux` from blacklist component
* Update `README` to account for blacklist changes and removed geofence
* Simplify `blacklist mutation`
* Added a help `tool tip` to explain how to enter blacklist terms

![image](https://user-images.githubusercontent.com/7232635/35344140-5b46a51a-00fa-11e8-9732-0ff9851b07ea.png)