### PR TITLE
Retry helm installs

### DIFF
--- a/project-fortis-pipeline/ops/install-cassandra.sh
+++ b/project-fortis-pipeline/ops/install-cassandra.sh
@@ -8,15 +8,21 @@ cd charts || exit -2
 readonly cluster_name="FORTIS_CASSANDRA"
 readonly storageClass="fast"
 
-# install cassandra
-helm install \
-  --set replicaCount="${k8cassandra_node_count}" \
-  --set VmInstanceType="${agent_vm_size}" \
-  --set cassandra.ClusterName="${cluster_name}" \
-  --set persistence.storageClass="${storageClass}" \
-  --namespace cassandra \
-  --name cassandra-cluster \
-  ./cassandra
+install_cassandra() {
+  helm install \
+    --set replicaCount="${k8cassandra_node_count}" \
+    --set VmInstanceType="${agent_vm_size}" \
+    --set cassandra.ClusterName="${cluster_name}" \
+    --set persistence.storageClass="${storageClass}" \
+    --namespace cassandra \
+    --name cassandra-cluster \
+    ./cassandra
+}
+
+while ! install_cassandra; do
+  echo "Failed to set up cassandra helm chart, retrying"
+  sleep 30s
+done
 
 # wait for all cassandra nodes to be ready
 while [ -z "$(kubectl --namespace=cassandra get svc cassandra-cluster-cassan-ext -o jsonpath='{..ip}')" ]; do


### PR DESCRIPTION
I saw one deployment where helm failed because an endpoint on the k8s infrastructure wasn't reachable. I'm wondering if we can harden the helm installs with this retry. Thoughts, @jmspring ?