### PR TITLE
Don't hard-code location of cognitive services

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -114,34 +114,6 @@
             },
             "type": "securestring"
         },
-        "cognitiveServicesTextAnalyticsToken": {
-            "metadata": {
-                "description": "Cognitive Services Text Analytics access token"
-            },
-            "defaultValue": "",
-            "type": "securestring"
-        },
-        "cognitiveServicesTextTranslationToken": {
-            "metadata": {
-                "description": "Cognitive Services Text Translation access token"
-            },
-            "defaultValue": "",
-            "type": "securestring"
-        },
-        "cognitiveServicesComputerVisionToken": {
-            "metadata": {
-                "description": "Cognitive Services Computer Vision access token"
-            },
-            "defaultValue": "",
-            "type": "securestring"
-        },
-        "cognitiveServicesBingSpeechToken": {
-            "metadata": {
-                "description": "Cognitive Services Bing Speech access token"
-            },
-            "defaultValue": "",
-            "type": "securestring"
-        },
         "fortisSiteCloneUrl": {
             "metadata": {
                 "description": "URL to exported Fortis site to clone"
@@ -617,7 +589,7 @@
                     "fileUris": [
                         "[variables('fortisDeployScriptFileUri')]"
                     ],
-                    "commandToExecute": "[concat('./fortis-deploy.sh', ' -fcu \"', parameters('fortisSiteCloneUrl'), '\" -ad \"', parameters('activeDirectoryClientId'), '\" -fa \"', parameters('fortisAdmins'), '\" -fu \"', parameters('fortisUsers'), '\" -lo \"', parameters('siteLocation'), '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -sn \"', parameters('siteName'), '\" -un \"', variables('adminUsername'), '\" -aii \"', reference(resourceId('Microsoft.Insights/components', variables('applicationInsightServiceName')), '2014-04-01').InstrumentationKey,'\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value,'\" -sty \"', parameters('siteType'), '\" -ai \"', parameters('servicePrincipalAppId'), '\" -sw \"', parameters('sparkWorkers'), '\" -cn \"', parameters('cassandraNodes'), '\" -ec \"', listKeys(variables('eventhubResource'), variables('ehVersion')).primaryConnectionString, '\" -sb \"', listkeys(variables('sbAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString, '\" -mat \"', parameters('mapboxAccessToken'), '\" -csst \"', parameters('cognitiveServicesBingSpeechToken'), '\" -tst \"', parameters('cognitiveServicesTextTranslationToken'), '\" -ctst \"', parameters('cognitiveServicesTextAnalyticsToken'), '\" -cvst \"', parameters('cognitiveServicesComputerVisionToken'), '\" -gc \"', variables('githubClonePath'), '\" -gr \"', parameters('githubProjectRelease'), '\" -avms \"', parameters('agentVMSize'), '\" -ep \"', parameters('endpointProtection'), '\" -ih \"', parameters('ingressHostname'), '\" -tc \"', parameters('tlsCertificate'), '\" -tk \"', parameters('tlsPrivateKey'), '\" -le \"', parameters('letsEncryptEmail'), '\" -lae \"', parameters('letsEncryptApiEndpoint'), '\"')]"
+                    "commandToExecute": "[concat('./fortis-deploy.sh', ' -fcu \"', parameters('fortisSiteCloneUrl'), '\" -ad \"', parameters('activeDirectoryClientId'), '\" -fa \"', parameters('fortisAdmins'), '\" -fu \"', parameters('fortisUsers'), '\" -lo \"', parameters('siteLocation'), '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -sn \"', parameters('siteName'), '\" -un \"', variables('adminUsername'), '\" -aii \"', reference(resourceId('Microsoft.Insights/components', variables('applicationInsightServiceName')), '2014-04-01').InstrumentationKey,'\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value,'\" -sty \"', parameters('siteType'), '\" -ai \"', parameters('servicePrincipalAppId'), '\" -sw \"', parameters('sparkWorkers'), '\" -cn \"', parameters('cassandraNodes'), '\" -ec \"', listKeys(variables('eventhubResource'), variables('ehVersion')).primaryConnectionString, '\" -sb \"', listkeys(variables('sbAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString, '\" -mat \"', parameters('mapboxAccessToken'), '\" -gc \"', variables('githubClonePath'), '\" -gr \"', parameters('githubProjectRelease'), '\" -avms \"', parameters('agentVMSize'), '\" -ep \"', parameters('endpointProtection'), '\" -ih \"', parameters('ingressHostname'), '\" -tc \"', parameters('tlsCertificate'), '\" -tk \"', parameters('tlsPrivateKey'), '\" -le \"', parameters('letsEncryptEmail'), '\" -lae \"', parameters('letsEncryptApiEndpoint'), '\"')]"
                 }
             }
         }

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -38,18 +38,6 @@
         "mapboxAccessToken": {
             "value": "CHANGE ME"
         },
-        "cognitiveServicesTextAnalyticsToken": {
-            "value": ""
-        },
-        "cognitiveServicesTextTranslationToken": {
-            "value": ""
-        },
-        "cognitiveServicesComputerVisionToken": {
-            "value": ""
-        },
-        "cognitiveServicesBingSpeechToken": {
-            "value": ""
-        },
         "fortisSiteCloneUrl": {
             "value": ""
         },

--- a/project-fortis-pipeline/fortis-deploy.sh
+++ b/project-fortis-pipeline/fortis-deploy.sh
@@ -46,10 +46,6 @@ Arguments
   --aad_client|-ad                   [Optional] : Active Directory Client Id to use for this deployment
   --fortis_admins|-fa                [Optional] : Email addresses of fortis admins, comma separated
   --fortis_users|-fu                 [Optional] : Email addresses of fortis users, comma separated
-  --cogvisionsvctoken|-cvst          [Optional] : Cognitive Services Vision access token
-  --cogtextsvctoken|-ctst            [Optional] : Cognitive Services Text access token
-  --cogspeechsvctoken|-csst          [Optional] : Cognitive Services Speech access token
-  --translationsvctoken|-tst         [Optional] : Cognitive Services Translation access token
   --fortis_site_clone_url|-fcu       [Optional] : URL to exported Fortis site to clone
   --endpoint_protection|-ep          [Optional] : What version of endpoint protection to use
   --ingress_hostname|-ih             [Optional] : Hostname for TLS ingress
@@ -188,22 +184,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mapbox_access_token|-mat)
       mapbox_access_token="$1"
-      shift
-      ;;
-    --cogvisionsvctoken|-cvst)
-      cogvisionsvctoken="$1"
-      shift
-      ;;
-    --cogtextsvctoken|-ctst)
-      cogtextsvctoken="$1"
-      shift
-      ;;
-    --cogspeechsvctoken|-csst)
-      cogspeechsvctoken="$1"
-      shift
-      ;;
-    --translationsvctoken|-tst)
-      translationsvctoken="$1"
       shift
       ;;
     --fortis_site_clone_url|-fcu)
@@ -357,30 +337,25 @@ az storage share create \
   --account-key "${storage_account_key}" \
   --account-name "${storage_account_name}"
 
-if [ -z "${cogvisionsvctoken}" ]; then
-  echo "Finished. Now setting up cognitive services vision account"
-  name="${storage_account_name}ComputerVision"
-  az cognitiveservices account create -l "${location}" --kind "ComputerVision" --sku "S1" --yes -g "${resource_group}" -n "${name}"
-  cogvisionsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
-fi
-if [ -z "${cogspeechsvctoken}" ]; then
-  echo "Finished. Now setting up cognitive services speech account"
-  name="${storage_account_name}STT"
-  az cognitiveservices account create -l "global" --kind "Bing.Speech" --sku "S0" --yes -g "${resource_group}" -n "${name}"
-  cogspeechsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
-fi
-if [ -z "${cogtextsvctoken}" ]; then
-  echo "Finished. Now setting up cognitive services text account"
-  name="${storage_account_name}NLP"
-  az cognitiveservices account create -l "${location}" --kind "TextAnalytics" --sku "S0" --yes -g "${resource_group}" -n "${name}"
-  cogtextsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
-fi
-if [ -z "${translationsvctoken}" ]; then
-  echo "Finished. Now setting up cognitive services translation account"
-  name="${storage_account_name}Translation"
-  az cognitiveservices account create -l "global" --kind "TextTranslation" --sku "S1" --yes -g "${resource_group}" -n "${name}"
-  translationsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
-fi
+echo "Finished. Now setting up cognitive services vision account"
+name="${storage_account_name}ComputerVision"
+az cognitiveservices account create -l "${location}" --kind "ComputerVision" --sku "S1" --yes -g "${resource_group}" -n "${name}"
+readonly cogvisionsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
+
+echo "Finished. Now setting up cognitive services speech account"
+name="${storage_account_name}STT"
+az cognitiveservices account create -l "global" --kind "Bing.Speech" --sku "S0" --yes -g "${resource_group}" -n "${name}"
+readonly cogspeechsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
+
+echo "Finished. Now setting up cognitive services text account"
+name="${storage_account_name}NLP"
+az cognitiveservices account create -l "${location}" --kind "TextAnalytics" --sku "S0" --yes -g "${resource_group}" -n "${name}"
+readonly cogtextsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
+
+echo "Finished. Now setting up cognitive services translation account"
+name="${storage_account_name}Translation"
+az cognitiveservices account create -l "global" --kind "TextTranslation" --sku "S1" --yes -g "${resource_group}" -n "${name}"
+readonly translationsvctoken="$(az cognitiveservices account keys list -g "${resource_group}" -n "${name}" --output tsv | cut -f1)"
 
 echo "Finished. Installing deployment scripts"
 if ! (command -v git >/dev/null); then sudo apt-get -qq install -y git; fi

--- a/project-fortis-pipeline/localdeploy/setup-development-azure-resources.sh
+++ b/project-fortis-pipeline/localdeploy/setup-development-azure-resources.sh
@@ -81,6 +81,7 @@ az postgres server firewall-rule create \
 # save environment variables
 
 echo "FORTIS_RESOURCE_GROUP_NAME=$resourceGroupName" | tee "$outputFile"
+echo "FORTIS_RESOURCE_GROUP_LOCATION=$resourceGroupLocation" | tee --append "$outputFile"
 
 echo "FEATURES_DB_USER=$postgresUser@$postgresName" | tee --append "$outputFile"
 echo "FEATURES_DB_HOST=$postgresName.postgres.database.azure.com" | tee --append "$outputFile"

--- a/project-fortis-pipeline/ops/create-cluster.sh
+++ b/project-fortis-pipeline/ops/create-cluster.sh
@@ -214,7 +214,8 @@ echo "Finished. Now installing Spark helm chart."
   "${latest_version}" \
   "${cassandra_port}" \
   "${cassandra_username}" \
-  "${cassandra_password}"
+  "${cassandra_password}" \
+  "${k8location}"
 
 echo "Finished. Now setting up fortis spark job upgrade script."
 if ! (command -v yaml > /dev/null); then npm install --global yaml-cli; fi

--- a/project-fortis-pipeline/ops/install-spark.sh
+++ b/project-fortis-pipeline/ops/install-spark.sh
@@ -27,6 +27,7 @@ readonly latest_version="${24}"
 readonly cassandra_port="${25}"
 readonly cassandra_username="${26}"
 readonly cassandra_password="${27}"
+readonly k8location="${28}"
 
 # setup
 cd charts || exit -2
@@ -55,6 +56,7 @@ EOF
 kubectl create -f "${namespace_yaml}"
 kubectl create configmap "${spark_config_map_name}" \
   --namespace spark \
+  --from-literal=FORTIS_RESOURCE_GROUP_LOCATION="${k8location}" \
   --from-literal=FORTIS_CASSANDRA_HOST="${cassandra_host}" \
   --from-literal=FORTIS_CASSANDRA_PORT="${cassandra_port}" \
   --from-literal=FORTIS_CASSANDRA_USERNAME="${cassandra_username}" \

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
@@ -20,6 +20,7 @@ object Constants {
     val BlobUrlBase = "FORTIS_CENTRAL_ASSETS_HOST"
     val CassandraHost = "FORTIS_CASSANDRA_HOST"
     val CassandraPort = "FORTIS_CASSANDRA_PORT"
+    val Location = "FORTIS_RESOURCE_GROUP_LOCATION"
     val CassandraUsername = "FORTIS_CASSANDRA_USERNAME"
     val CassandraPassword = "FORTIS_CASSANDRA_PASSWORD"
     val ManagementBusConnectionString = "FORTIS_SB_CONN_STR"

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/FortisSettings.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/FortisSettings.scala
@@ -3,6 +3,7 @@ package com.microsoft.partnercatalyst.fortis.spark
 case class FortisSettings(
   progressDir: String,
   featureServiceUrlBase: String,
+  cognitiveUrlBase: String,
   blobUrlBase: String,
   cassandraHosts: String,
   cassandraPorts: String,

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
@@ -27,6 +27,7 @@ object ProjectFortis extends App {
     FortisSettings(
       // Required
       featureServiceUrlBase = envOrFail(Constants.Env.FeatureServiceUrlBase),
+      cognitiveUrlBase = s"https://${envOrFail(Constants.Env.Location).replace(" ", "").toLowerCase}.api.cognitive.microsoft.com",
       cassandraHosts = envOrFail(Constants.Env.CassandraHost),
       cassandraPorts = envOrFail(Constants.Env.CassandraPort),
       cassandraUsername = envOrFail(Constants.Env.CassandraUsername),
@@ -77,7 +78,7 @@ object ProjectFortis extends App {
   private def attachToContext(ssc:StreamingContext): Boolean = {
     val configManager = new CassandraConfigurationManager
     val streamProvider = StreamProviderFactory.create(configManager)
-    val transformContextProvider = new TransformContextProvider(configManager, fortisSettings.featureServiceUrlBase)
+    val transformContextProvider = new TransformContextProvider(configManager, fortisSettings.featureServiceUrlBase, fortisSettings.cognitiveUrlBase)
 
     def pipeline[T: TypeTag](name: String, analyzer: Analyzer[T]) =
       Pipeline(name, analyzer, ssc, streamProvider, transformContextProvider, configManager)

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/Delta.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/Delta.scala
@@ -30,6 +30,7 @@ private[transformcontext] object Delta {
   def apply(
     transformContext: TransformContext,
     featureServiceClientUrlBase: String,
+    cognitiveUrlBase: String,
     siteSettings: Option[SiteSettings] = None,
     langToWatchlist: Option[Map[String, Seq[String]]] = None,
     blacklist: Option[Seq[BlacklistedItem]] = None)(implicit settings: FortisSettings): Delta =
@@ -66,12 +67,12 @@ private[transformcontext] object Delta {
         siteSettings.get.cogvisionsvctoken != transformContext.siteSettings.cogvisionsvctoken
         || siteSettings.get.featureservicenamespace != transformContext.siteSettings.featureservicenamespace,
         new ImageAnalyzer(
-          ImageAnalysisAuth(siteSettings.get.cogvisionsvctoken),
+          ImageAnalysisAuth(siteSettings.get.cogvisionsvctoken, cognitiveUrlBase),
           new FeatureServiceClient(featureServiceClientUrlBase, siteSettings.get.featureservicenamespace))
       ),
       sentimentDetectorAuth = updatedField(
         siteSettings.get.cogtextsvctoken != transformContext.siteSettings.cogtextsvctoken,
-        SentimentDetectorAuth(siteSettings.get.cogtextsvctoken)
+        SentimentDetectorAuth(siteSettings.get.cogtextsvctoken, cognitiveUrlBase)
       ),
       langToKeywordExtractor = langToWatchlist.map(
         m => m.transform((lang, terms)=>new LuceneKeywordExtractor(lang, terms, settings.maxKeywordsPerEvent))

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/TransformContextProvider.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/TransformContextProvider.scala
@@ -12,7 +12,7 @@ import com.microsoft.partnercatalyst.fortis.spark.logging.FortisTelemetry.{get =
 import org.apache.spark.SparkContext
 
 @SerialVersionUID(100L)
-class TransformContextProvider(configManager: ConfigurationManager, featureServiceClientUrlBase: String)
+class TransformContextProvider(configManager: ConfigurationManager, featureServiceClientUrlBase: String, cognitiveUrlBase: String)
   (implicit settings: FortisSettings) extends Serializable
 {
   private val deltaChannel: SynchronousQueue[Delta] = new SynchronousQueue[Delta]()
@@ -56,7 +56,7 @@ class TransformContextProvider(configManager: ConfigurationManager, featureServi
           val langToWatchlist = configManager.fetchWatchlist(sparkContext)
           val blacklist = configManager.fetchBlacklist(sparkContext)
 
-          val delta = Delta(TransformContext(), featureServiceClientUrlBase, Some(siteSettings), Some(langToWatchlist), Some(blacklist))
+          val delta = Delta(TransformContext(), featureServiceClientUrlBase, cognitiveUrlBase, Some(siteSettings), Some(langToWatchlist), Some(blacklist))
 
           updateTransformContextAndBroadcast(delta, sparkContext)
           startQueueClient(sparkContext)
@@ -135,15 +135,15 @@ class TransformContextProvider(configManager: ConfigurationManager, featureServi
             case "settings" =>
               val siteSettings = configManager.fetchSiteSettings(sparkContext)
               Log.logDependency("pipeline.settings", "transformcontext.messageHandler", success = true, durationInMs = 0)
-              Delta(transformContext, featureServiceClientUrlBase, siteSettings = Some(siteSettings))
+              Delta(transformContext, featureServiceClientUrlBase, cognitiveUrlBase, siteSettings = Some(siteSettings))
             case "watchlist" =>
               val langToWatchlist = configManager.fetchWatchlist(sparkContext)
               Log.logDependency("pipeline.settings", "transformcontext.messageHandler", success = true, durationInMs = 0)
-              Delta(transformContext, featureServiceClientUrlBase, langToWatchlist = Some(langToWatchlist))
+              Delta(transformContext, featureServiceClientUrlBase, cognitiveUrlBase, langToWatchlist = Some(langToWatchlist))
             case "blacklist" =>
               val blacklist = configManager.fetchBlacklist(sparkContext)
               Log.logDependency("pipeline.settings", "transformcontext.messageHandler", success = true, durationInMs = 0)
-              Delta(transformContext, featureServiceClientUrlBase, blacklist = Some(blacklist))
+              Delta(transformContext, featureServiceClientUrlBase, cognitiveUrlBase, blacklist = Some(blacklist))
 
             case unknown =>
               Log.logError(s"Service Bus client received unexpected update request. Ignoring.: $unknown")

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
@@ -7,10 +7,9 @@ import com.microsoft.partnercatalyst.fortis.spark.logging.FortisTelemetry
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto.FeatureServiceFeature.toLocation
 import net.liftweb.json
-
 import scalaj.http.Http
 
-case class ImageAnalysisAuth(key: String, apiUrlBase: String = "https://westus.api.cognitive.microsoft.com")
+case class ImageAnalysisAuth(key: String, apiUrlBase: String)
 
 @SerialVersionUID(100L)
 class ImageAnalyzer(auth: ImageAnalysisAuth, featureServiceClient: FeatureServiceClient) extends Serializable {

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/CognitiveServicesLanguageDetector.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/CognitiveServicesLanguageDetector.scala
@@ -4,10 +4,9 @@ import java.lang.System.currentTimeMillis
 
 import com.microsoft.partnercatalyst.fortis.spark.logging.FortisTelemetry
 import net.liftweb.json
-
 import scalaj.http.Http
 
-case class CognitiveServicesLanguageDetectorAuth(key: String, apiUrlBase: String = "https://westus.api.cognitive.microsoft.com")
+case class CognitiveServicesLanguageDetectorAuth(key: String, apiUrlBase: String)
 
 @SerialVersionUID(100L)
 class CognitiveServicesLanguageDetector(

--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetector.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetector.scala
@@ -4,10 +4,9 @@ import java.lang.System.currentTimeMillis
 
 import com.microsoft.partnercatalyst.fortis.spark.logging.FortisTelemetry
 import net.liftweb.json
-
 import scalaj.http.Http
 
-case class SentimentDetectorAuth(key: String, apiUrlBase: String = "https://westus.api.cognitive.microsoft.com")
+case class SentimentDetectorAuth(key: String, apiUrlBase: String)
 
 @SerialVersionUID(100L)
 class CognitiveServicesSentimentDetector(

--- a/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/StreamsChangeListenerTestSpec.scala
+++ b/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/StreamsChangeListenerTestSpec.scala
@@ -16,6 +16,7 @@ class StreamsChangeListenerTestSpec extends FlatSpec with BeforeAndAfter {
   val settings = FortisSettings(
     "/tmp/test_fortis_progress_dir_" + UUID.randomUUID(),
     "https://featurehost",
+    "https://cognitivehost",
     "https://blobhost",
     "cassandraHosts",
     "cassandraPorts",

--- a/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
+++ b/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
@@ -4,7 +4,7 @@ import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, Location, Tag}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.image.dto.JsonImageLandmark
 import org.scalatest.FlatSpec
 
-class TestImageAnalyzer(cognitiveServicesResponse: String) extends ImageAnalyzer(ImageAnalysisAuth("key"), null) {
+class TestImageAnalyzer(cognitiveServicesResponse: String) extends ImageAnalyzer(ImageAnalysisAuth("key", "host"), null) {
   override protected def callCognitiveServices(requestBody: String): String = cognitiveServicesResponse
   override def buildRequestBody(imageUrl: String): String = super.buildRequestBody(imageUrl)
   override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, name = x.name, layer = "", latitude = -1, longitude = -1, confidence = Some(x.confidence)))

--- a/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/CognitiveServicesLanguageDetectorSpec.scala
+++ b/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/CognitiveServicesLanguageDetectorSpec.scala
@@ -2,7 +2,7 @@ package com.microsoft.partnercatalyst.fortis.spark.transforms.language
 
 import org.scalatest.FlatSpec
 
-class TestCognitiveServicesLanguageDetector(cognitiveServicesResponse: String) extends CognitiveServicesLanguageDetector(CognitiveServicesLanguageDetectorAuth("key")) {
+class TestCognitiveServicesLanguageDetector(cognitiveServicesResponse: String) extends CognitiveServicesLanguageDetector(CognitiveServicesLanguageDetectorAuth("key", "host")) {
   protected override def callCognitiveServices(request: String): String = cognitiveServicesResponse
   override def buildRequestBody(text: String, textId: String): String = super.buildRequestBody(text, textId)
 }

--- a/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetectorSpec.scala
+++ b/project-fortis-spark/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetectorSpec.scala
@@ -2,7 +2,7 @@ package com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment
 
 import org.scalatest.FlatSpec
 
-class TestCognitiveServicesSentimentDetector(cognitiveServicesResponse: String, language: String) extends CognitiveServicesSentimentDetector(language, SentimentDetectorAuth("key")) {
+class TestCognitiveServicesSentimentDetector(cognitiveServicesResponse: String, language: String) extends CognitiveServicesSentimentDetector(language, SentimentDetectorAuth("key", "host")) {
   protected override def callCognitiveServices(request: String): String = cognitiveServicesResponse
   override def buildRequestBody(text: String, textId: String): String = super.buildRequestBody(text, textId)
 }


### PR DESCRIPTION
Previously we were assuming that the cognitive services called in the
spark jobs are always deployed in WESTUS which leads to failed calls
when the resources are set up somewhere else, e.g. in EASTUS. This
change passes the resource group location in which the cognitive
services were created through to spark so that we can format the
appropriate base URL for the services.

As a tangential change, this commit also removes the ability to provide
cognitive services tokens at deploy time. We already have the ability to
set up new cognitive services accounts during the fortis-deploy.sh
script so we might as well leverage that to ensure that the cognitive
services tokens and deployment locations don't risk getting out of sync
which will lead to hard to debug errors for the user. This changes also
has some related benefits, e.g. making billing more straight forward
since all Fortis resources will be located in the same resource group by
construction.