### PR TITLE
Ensure twitter track terms are 60 bytes or less

### DIFF
--- a/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/TwitterStreamFactory.scala
+++ b/project-fortis-spark/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/TwitterStreamFactory.scala
@@ -97,7 +97,7 @@ class TwitterStreamFactory(configurationManager: ConfigurationManager) extends S
 
     val maxTerms = twitterMaxTermCount
     val updatedWatchlistCurrentOffsetValue = watchlistCurrentOffsetValue + maxTerms
-    val selectedTerms = terms.take(maxTerms)
+    val selectedTerms = terms.filter(_.getBytes("UTF-8").length < 60).take(maxTerms)
     query.track(selectedTerms:_*)
 
     sparkContext.setLocalProperty(watchlistCurrentOffsetKey, updatedWatchlistCurrentOffsetValue.toString)


### PR DESCRIPTION
We already enforce this restriction at the GraphQL level for any terms
added through the UI, but bad terms can still get through, e.g. via site
import/export. This change improves our defensiveness and removes
known-bad terms.