### PR TITLE
Stream save fix

### DIFF
--- a/project-fortis-interfaces/src/actions/Admin/index.js
+++ b/project-fortis-interfaces/src/actions/Admin/index.js
@@ -150,6 +150,11 @@ const _methods = {
     },
 
     save_stream(streams) {
+      if (!streams || streams.length === 0) {
+        this.dispatch(constants.ADMIN.LOAD_STREAMS, { action: 'saved', response: this.flux.stores.AdminStore.dataStore.streams });
+        return;
+      }
+      
       AdminServices.saveStreams(streams, (err, response, body) => ResponseHandler(err, response, body, (error, graphqlResponse) => {
         if (graphqlResponse) {
           const streamsListed = this.flux.stores.AdminStore.dataStore.streams;

--- a/project-fortis-interfaces/src/actions/Admin/index.js
+++ b/project-fortis-interfaces/src/actions/Admin/index.js
@@ -150,11 +150,8 @@ const _methods = {
     },
 
     save_stream(streams) {
-      if (!streams || streams.length === 0) {
-        this.dispatch(constants.ADMIN.LOAD_STREAMS, { action: 'saved', response: this.flux.stores.AdminStore.dataStore.streams });
-        return;
-      }
-      
+      if (!streams || streams.length === 0) return;
+
       AdminServices.saveStreams(streams, (err, response, body) => ResponseHandler(err, response, body, (error, graphqlResponse) => {
         if (graphqlResponse) {
           const streamsListed = this.flux.stores.AdminStore.dataStore.streams;


### PR DESCRIPTION
This prevents:
`Error, could not load streams for admin page` with a backend error of `No streams specified` 

Bug used to happen when setting the enabled flag, selecting the stream, and then hitting "upload changes".