### PR TITLE
Change FacebookPage to FacebookPost.

### DIFF
--- a/project-fortis-interfaces/src/components/Admin/Streams/StreamConstants.js
+++ b/project-fortis-interfaces/src/components/Admin/Streams/StreamConstants.js
@@ -275,7 +275,7 @@ const defaultStreamMap = {
     pipelineKey: 'Facebook',
     pipelineLabel: 'Facebook',
     pipelineIcon: EVENT_SOURCE_ICON_MAP.facebook,
-    streamFactory: 'FacebookPost',
+    streamFactory: 'FacebookPage',
     enabled: true
   },
   HTML: {


### PR DESCRIPTION
Since we're picking one stream factory, facebook post would be better since it would contain more information.