### PR TITLE
Update fortis-deploy.sh

### DIFF
--- a/project-fortis-pipeline/fortis-deploy.sh
+++ b/project-fortis-pipeline/fortis-deploy.sh
@@ -215,8 +215,8 @@ done
 
 install_azure_cli() {
   sudo apt-get -qq update && sudo apt-get -qq install -y libssl-dev libffi-dev python-dev
-  echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-  sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+  echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" |sudo tee /etc/apt/sources.list.d/azure-cli.list
+  curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
   sudo apt-get -qq install -y apt-transport-https
   sudo apt-get -qq update && sudo apt-get -qq install -y azure-cli
 }


### PR DESCRIPTION
Fixes issue with deploy failing. The way of installing Azure CLI has been updated. There are new issues that have to do with the frontend/react that we're working on separately.